### PR TITLE
sys: also try loading kadm5 libraries by SONAME

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -75,7 +75,7 @@ jobs:
         job:
           - mit
           # Several issues in k5test preventing us from running kadmind with it currently
-          # - h5l
+          # - heimdal
         python-version:
           - "3.11"
           - "pypy3.11"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "goblin"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "983a6aafb3b12d4c41ea78d39e189af4298ce747353945ff5105b54a056e5cd9"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +428,7 @@ dependencies = [
  "chrono",
  "dlopen2",
  "getset",
+ "goblin",
  "indoc",
  "libc",
  "log",
@@ -588,6 +600,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -792,6 +810,26 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scroll"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1257cd4248b4132760d6524d6dda4e053bc648c9070b960929bf50cfb1e7add"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed76efe62313ab6610570951494bdaa81568026e0318eaa55f167de70eeea67d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "sdd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ prettyplease = "0.2"
 quote = "1.0"
 strum = { version = "0.28", features = ["derive"] }
 syn = { version = "2.0", features = ["full", "parsing"] }
+goblin = "0.10.5"
 
 [dev-dependencies]
 anyhow = "1"

--- a/build.rs
+++ b/build.rs
@@ -206,6 +206,7 @@ struct KAdm5Config {
     include_paths: HashSet<PathBuf>,
     library_paths: HashSet<PathBuf>,
     libraries: HashSet<String>,
+    sonames: HashSet<String>,
 }
 
 impl KAdm5Config {
@@ -232,11 +233,21 @@ impl KAdm5Config {
                 .collect::<Vec<String>>()
                 .join(" ")
         );
+        println!(
+            "cargo::rustc-env=KADMIN_BUILD_{}_SONAMES={}",
+            self.name().to_uppercase(),
+            self.sonames
+                .iter()
+                .cloned()
+                .collect::<Vec<String>>()
+                .join(" ")
+        );
     }
 
     fn extend(&mut self, other: &Self) {
         self.library_paths.extend(other.library_paths.clone());
         self.libraries.extend(other.libraries.clone());
+        self.sonames.extend(other.sonames.clone());
     }
 }
 
@@ -253,8 +264,8 @@ fn main() {
         println!("cargo:rustc-cfg={}", config.name());
         println!(
             "cargo::warning=Found MIT Kerberos kadm5-client. Includes: {:?}. Links: {:?}. \
-             Libraries: {:?}",
-            config.include_paths, config.library_paths, config.libraries,
+             Libraries: {:?}. SONAMEs: {:?}",
+            config.include_paths, config.library_paths, config.libraries, config.sonames,
         );
         generate_bindings(&config, &out_path);
         found_any = true;
@@ -264,8 +275,8 @@ fn main() {
         println!("cargo:rustc-cfg={}", config.name());
         println!(
             "cargo::warning=Found MIT Kerberos kadm5-server. Includes: {:?}. Links: {:?}. \
-             Libraries: {:?}",
-            config.include_paths, config.library_paths, config.libraries,
+             Libraries: {:?}. SONAMEs: {:?}",
+            config.include_paths, config.library_paths, config.libraries, config.sonames,
         );
         generate_bindings(&config, &out_path);
         found_any = true;
@@ -276,8 +287,8 @@ fn main() {
         println!("cargo:rustc-cfg={}", config.name());
         println!(
             "cargo::warning=Found Heimdal Kerberos kadm5-client. Includes: {:?}. Links: {:?}. \
-             Libraries: {:?}",
-            config.include_paths, config.library_paths, config.libraries,
+             Libraries: {:?}. SONAMEs: {:?}",
+            config.include_paths, config.library_paths, config.libraries, config.sonames,
         );
         generate_bindings(&config, &out_path);
         found_any = true;
@@ -288,8 +299,8 @@ fn main() {
         println!("cargo:rustc-cfg={}", config.name());
         println!(
             "cargo::warning=Found Heimdal Kerberos kadm5-server. Includes: {:?}. Links: {:?}. \
-             Libraries: {:?}",
-            config.include_paths, config.library_paths, config.libraries,
+             Libraries: {:?}. SONAMEs: {:?}",
+            config.include_paths, config.library_paths, config.libraries, config.sonames,
         );
         generate_bindings(&config, &out_path);
         found_any = true;
@@ -335,6 +346,7 @@ fn try_overrides(variant: KAdm5Variant) -> Option<KAdm5Config> {
                 .collect(),
             library_paths: HashSet::new(),
             libraries: HashSet::new(),
+            sonames: HashSet::new(),
         });
     }
     None
@@ -406,16 +418,42 @@ fn probe_krb5_config(bin: &str, lib: Option<&str>, variant: KAdm5Variant) -> Opt
     for include_path in &include_paths {
         let header_path = include_path.join("kadm5/admin.h");
         if header_path.exists() && variant.verify_header_variant(&header_path) {
+            let sonames = discover_sonames(&library_paths, &libraries);
             return Some(KAdm5Config {
                 variant,
                 include_paths,
                 library_paths,
                 libraries,
+                sonames,
             });
         }
     }
 
     None
+}
+
+fn discover_sonames(
+    library_paths: &HashSet<PathBuf>,
+    libraries: &HashSet<String>,
+) -> HashSet<String> {
+    let mut out = HashSet::new();
+    for lib in libraries {
+        for path in library_paths {
+            if let Some(soname) = discover_soname(path, lib) {
+                out.insert(soname);
+                break;
+            }
+        }
+    }
+    out
+}
+
+fn discover_soname(library_path: &Path, library: &str) -> Option<String> {
+    let unversioned = library_path.join(format!("lib{library}.so"));
+    let canonical = std::fs::canonicalize(&unversioned).ok()?;
+    let bytes = std::fs::read(&canonical).ok()?;
+    let elf = goblin::elf::Elf::parse(&bytes).ok()?;
+    elf.soname.map(str::to_owned)
 }
 
 fn try_pkg_config(variant: KAdm5Variant) -> Option<KAdm5Config> {
@@ -440,15 +478,21 @@ fn probe_from_pkg_config(lib: pkg_config::Library, variant: KAdm5Variant) -> Opt
     for include_path in &lib.include_paths {
         let header_path = include_path.join("kadm5/admin.h");
         if header_path.exists() && variant.verify_header_variant(&header_path) {
+            let library_paths = HashSet::from_iter(lib.link_paths.iter().cloned());
+            let libraries: HashSet<String> = lib
+                .libs
+                .iter()
+                .filter(|lib| lib.contains("kadm5"))
+                .cloned()
+                .collect();
+            let sonames = discover_sonames(&library_paths, &libraries);
+
             return Some(KAdm5Config {
                 variant,
                 include_paths: HashSet::from_iter(lib.include_paths.iter().cloned()),
-                library_paths: HashSet::from_iter(lib.link_paths.iter().cloned()),
-                libraries: lib
-                    .libs
-                    .into_iter()
-                    .filter(|lib| lib.contains("kadm5"))
-                    .collect(),
+                library_paths,
+                libraries,
+                sonames,
             });
         }
     }

--- a/justfile
+++ b/justfile
@@ -91,10 +91,10 @@ ci-test-deps:
   sudo apt-get install -y --no-install-recommends valgrind
 [private]
 ci-test-deps-mit: ci-test-deps
-  sudo apt-get install -y --no-install-recommends libkrb5-3 libkadm5clnt-mit12 libkadm5srv-mit12 krb5-kdc krb5-user krb5-admin-server
+  sudo apt-get install -y --no-install-recommends libkadm5clnt-mit12 libkadm5srv-mit12 krb5-kdc krb5-user krb5-admin-server
 [private]
 ci-test-deps-heimdal: ci-test-deps
-  sudo apt-get install -y --no-install-recommends libkrb5-26t64-heimdal libkadm5clnt7t64-heimdal libkadm5srv8t64-heimdal heimdal-clients heimdal-kdc
+  sudo apt-get install -y --no-install-recommends libkadm5clnt7t64-heimdal libkadm5srv8t64-heimdal heimdal-clients heimdal-servers heimdal-kdc
 [private]
 ci-test-rust-mit: ci-build-deps ci-test-deps-mit test-rust-mit
 [private]
@@ -120,12 +120,9 @@ _test-python:
 # Test python bindings
 test-python: install-python _test-python
 [private]
-ci-test-deps-h5l: ci-test-deps
-  sudo apt-get install -y --no-install-recommends libkrb5-3 libkadm5clnt-mit12 libkadm5srv-mit12 heimdal-dev heimdal-servers heimdal-kdc
-[private]
 ci-test-python-mit: ci-test-deps-mit _install-python _test-python
 [private]
-ci-test-python-h5l: ci-test-deps-h5l _install-python _test-python
+ci-test-python-heimdal: ci-test-deps-heimdal _install-python _test-python
 
 # Test rust crates and python bindings
 test-all: test-rust-mit test-sanity-mit test-python

--- a/justfile
+++ b/justfile
@@ -91,10 +91,10 @@ ci-test-deps:
   sudo apt-get install -y --no-install-recommends valgrind
 [private]
 ci-test-deps-mit: ci-test-deps
-  sudo apt-get install -y --no-install-recommends libkadm5clnt-mit12 libkadm5srv-mit12 krb5-config krb5-kdc krb5-user krb5-admin-server
+  sudo apt-get install -y --no-install-recommends libkadm5clnt-mit12 libkadm5srv-mit12 libkrb5-dev krb5-kdc krb5-user krb5-admin-server
 [private]
 ci-test-deps-heimdal: ci-test-deps
-  sudo apt-get install -y --no-install-recommends libkadm5clnt7t64-heimdal libkadm5srv8t64-heimdal krb5-config heimdal-clients heimdal-servers heimdal-kdc
+  sudo apt-get install -y --no-install-recommends libkadm5clnt7t64-heimdal libkadm5srv8t64-heimdal heimdal-dev heimdal-clients heimdal-servers heimdal-kdc
 [private]
 ci-test-rust-mit: ci-build-deps ci-test-deps-mit test-rust-mit
 [private]

--- a/justfile
+++ b/justfile
@@ -99,7 +99,6 @@ ci-test-deps-heimdal: ci-test-deps
 ci-test-rust-mit: ci-build-deps ci-test-deps-mit test-rust-mit
 [private]
 ci-test-rust-heimdal: ci-build-deps ci-test-deps-heimdal test-rust-heimdal
-  just test-rust-heimdal
 
 alias ts := test-sanity-mit
 # Test kadmin with valgrind for memory leaks, only MIT variants
@@ -109,11 +108,9 @@ test-sanity-mit:
 test-sanity-heimdal:
   CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="valgrind --error-exitcode=1 --suppressions=tests/valgrind.supp -s --leak-check=full" just test-rust-heimdal
 [private]
-ci-test-sanity-mit: ci-test-deps-mit
-  just test-sanity-mit
+ci-test-sanity-mit: ci-build-deps ci-test-deps-mit test-sanity-mit
 [private]
-ci-test-sanity-heimdal: ci-test-deps-heimdal
-  just test-sanity-heimdal
+ci-test-sanity-heimdal: ci-build-deps ci-test-deps-heimdal test-sanity-heimdal
 
 _test-python:
   uv run python -m unittest --verbose python/tests/test_*.py

--- a/justfile
+++ b/justfile
@@ -90,15 +90,15 @@ test-rust-heimdal:
 ci-test-deps:
   sudo apt-get install -y --no-install-recommends valgrind
 [private]
-ci-test-deps-mit: ci-build-deps ci-test-deps
-  sudo apt-get install -y --no-install-recommends krb5-kdc krb5-user krb5-admin-server
+ci-test-deps-mit: ci-test-deps
+  sudo apt-get install -y --no-install-recommends libkrb5-3 libkadm5clnt-mit12 libkadm5srv-mit12 krb5-kdc krb5-user krb5-admin-server
 [private]
-ci-test-deps-heimdal: ci-build-deps ci-test-deps
-  sudo apt-get install -y --no-install-recommends heimdal-clients heimdal-kdc
+ci-test-deps-heimdal: ci-test-deps
+  sudo apt-get install -y --no-install-recommends libkrb5-26t64-heimdal libkadm5clnt7t64-heimdal libkadm5srv8t64-heimdal heimdal-clients heimdal-kdc
 [private]
-ci-test-rust-mit: ci-test-deps-mit test-rust-mit
+ci-test-rust-mit: ci-build-deps ci-test-deps-mit test-rust-mit
 [private]
-ci-test-rust-heimdal: ci-test-deps-heimdal test-rust-heimdal
+ci-test-rust-heimdal: ci-build-deps ci-test-deps-heimdal test-rust-heimdal
   just test-rust-heimdal
 
 alias ts := test-sanity-mit

--- a/justfile
+++ b/justfile
@@ -91,10 +91,10 @@ ci-test-deps:
   sudo apt-get install -y --no-install-recommends valgrind
 [private]
 ci-test-deps-mit: ci-test-deps
-  sudo apt-get install -y --no-install-recommends libkadm5clnt-mit12 libkadm5srv-mit12 krb5-kdc krb5-user krb5-admin-server
+  sudo apt-get install -y --no-install-recommends libkadm5clnt-mit12 libkadm5srv-mit12 krb5-config krb5-kdc krb5-user krb5-admin-server
 [private]
 ci-test-deps-heimdal: ci-test-deps
-  sudo apt-get install -y --no-install-recommends libkadm5clnt7t64-heimdal libkadm5srv8t64-heimdal heimdal-clients heimdal-servers heimdal-kdc
+  sudo apt-get install -y --no-install-recommends libkadm5clnt7t64-heimdal libkadm5srv8t64-heimdal krb5-config heimdal-clients heimdal-servers heimdal-kdc
 [private]
 ci-test-rust-mit: ci-build-deps ci-test-deps-mit test-rust-mit
 [private]

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -169,16 +169,18 @@ impl Library {
             #[cfg(feature = "log")]
             log::trace!("Trying to load library at path {full_path}");
             let load = unsafe { Container::load(full_path) };
-            #[cfg(feature = "log")]
-            if let Err(err) = &load {
-                log::trace!("Loading library at path {full_path} resulted in an error: {err}");
+            match load {
+                Ok(cont) => {
+                    #[cfg(feature = "log")]
+                    log::trace!("Successfully loaded library at {full_path}");
+                    Some(cont)
+                }
+                Err(_err) => {
+                    #[cfg(feature = "log")]
+                    log::trace!("Loading library at path {full_path} resulted in an error: {_err}");
+                    None
+                }
             }
-            if let Ok(cont) = load {
-                #[cfg(feature = "log")]
-                log::trace!("Successfully loaded library at {full_path}");
-                return Some(cont);
-            }
-            None
         };
 
         for soname in &sonames {

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -169,18 +169,15 @@ impl Library {
             #[cfg(feature = "log")]
             log::trace!("Trying to load library at path {full_path}");
             let load = unsafe { Container::load(full_path) };
-            match load {
-                Ok(cont) => {
-                    #[cfg(feature = "log")]
-                    log::trace!("Successfully loaded library at {full_path}");
-                    Some(cont)
-                }
-                Err(_err) => {
-                    #[cfg(feature = "log")]
-                    log::trace!("Loading library at path {full_path} resulted in an error: {_err}");
-                    None
-                }
-            }
+            load.inspect(|_| {
+                #[cfg(feature = "log")]
+                log::trace!("Successfully loaded library at {full_path}");
+            })
+            .inspect_err(|_err| {
+                #[cfg(feature = "log")]
+                log::trace!("Loading library at path {full_path} resulted in an error: {_err}");
+            })
+            .ok()
         };
 
         for soname in &sonames {

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -163,20 +163,33 @@ impl Library {
     fn find_library<T: WrapperApi>(
         library_paths: Vec<&'static str>,
         libraries: Vec<&'static str>,
+        sonames: Vec<&'static str>,
     ) -> Option<Container<T>> {
-        for path in library_paths {
-            for library in libraries.iter() {
-                let full_path = format!("{}/lib{}.so", path, library);
+        let try_load = |full_path: &str| -> Option<Container<T>> {
+            #[cfg(feature = "log")]
+            log::trace!("Trying to load library at path {full_path}");
+            let load = unsafe { Container::load(full_path) };
+            #[cfg(feature = "log")]
+            if let Err(err) = &load {
+                log::trace!("Loading library at path {full_path} resulted in an error: {err}");
+            }
+            if let Ok(cont) = load {
                 #[cfg(feature = "log")]
-                log::trace!("Trying to load library at path {full_path}");
-                let load = unsafe { Container::load(&full_path) };
-                #[cfg(feature = "log")]
-                if let Err(err) = &load {
-                    log::trace!("Loading library at path {full_path} resulted in an error: {err}");
-                }
-                if let Ok(cont) = load {
-                    #[cfg(feature = "log")]
-                    log::trace!("Successfully loaded library at {full_path}");
+                log::trace!("Successfully loaded library at {full_path}");
+                return Some(cont);
+            }
+            None
+        };
+
+        for soname in &sonames {
+            if let Some(cont) = try_load(soname) {
+                return Some(cont);
+            }
+        }
+
+        for path in &library_paths {
+            for library in &libraries {
+                if let Some(cont) = try_load(&format!("{path}/lib{library}.so")) {
                     return Some(cont);
                 }
             }
@@ -191,9 +204,11 @@ impl Library {
         Ok(match variant {
             #[cfg(mit_client)]
             KAdm5Variant::MitClient => {
-                if let Some(cont) =
-                    Self::find_library(mit_client::library_paths(), mit_client::libraries())
-                {
+                if let Some(cont) = Self::find_library(
+                    mit_client::library_paths(),
+                    mit_client::libraries(),
+                    mit_client::sonames(),
+                ) {
                     Library::MitClient(cont)
                 } else {
                     Library::MitClient(unsafe { Container::load("libkadm5clnt_mit.so") }?)
@@ -201,9 +216,11 @@ impl Library {
             }
             #[cfg(mit_server)]
             KAdm5Variant::MitServer => {
-                if let Some(cont) =
-                    Self::find_library(mit_server::library_paths(), mit_server::libraries())
-                {
+                if let Some(cont) = Self::find_library(
+                    mit_server::library_paths(),
+                    mit_server::libraries(),
+                    mit_server::sonames(),
+                ) {
                     Library::MitServer(cont)
                 } else {
                     Library::MitServer(unsafe { Container::load("libkadm5srv_mit.so") }?)
@@ -211,9 +228,11 @@ impl Library {
             }
             #[cfg(heimdal_client)]
             KAdm5Variant::HeimdalClient => {
-                if let Some(cont) =
-                    Self::find_library(heimdal_client::library_paths(), heimdal_client::libraries())
-                {
+                if let Some(cont) = Self::find_library(
+                    heimdal_client::library_paths(),
+                    heimdal_client::libraries(),
+                    heimdal_client::sonames(),
+                ) {
                     Library::HeimdalClient(cont)
                 } else {
                     Library::HeimdalClient(unsafe { Container::load("libkadm5clnt.so") }?)
@@ -221,9 +240,11 @@ impl Library {
             }
             #[cfg(heimdal_server)]
             KAdm5Variant::HeimdalServer => {
-                if let Some(cont) =
-                    Self::find_library(heimdal_server::library_paths(), heimdal_server::libraries())
-                {
+                if let Some(cont) = Self::find_library(
+                    heimdal_server::library_paths(),
+                    heimdal_server::libraries(),
+                    heimdal_server::sonames(),
+                ) {
                     Library::HeimdalServer(cont)
                 } else {
                     Library::HeimdalServer(unsafe { Container::load("libkadm5srv.so") }?)
@@ -272,6 +293,12 @@ pub mod mit_client {
             .collect()
     }
 
+    pub fn sonames() -> Vec<&'static str> {
+        env!("KADMIN_BUILD_MIT_CLIENT_SONAMES")
+            .split_whitespace()
+            .collect()
+    }
+
     include!(concat!(env!("OUT_DIR"), "/bindings_mit_client.rs"));
 }
 
@@ -292,6 +319,12 @@ pub mod mit_server {
 
     pub fn libraries() -> Vec<&'static str> {
         env!("KADMIN_BUILD_MIT_SERVER_LIBRARIES")
+            .split_whitespace()
+            .collect()
+    }
+
+    pub fn sonames() -> Vec<&'static str> {
+        env!("KADMIN_BUILD_MIT_SERVER_SONAMES")
             .split_whitespace()
             .collect()
     }
@@ -327,6 +360,12 @@ pub mod heimdal_client {
             .collect()
     }
 
+    pub fn sonames() -> Vec<&'static str> {
+        env!("KADMIN_BUILD_HEIMDAL_CLIENT_SONAMES")
+            .split_whitespace()
+            .collect()
+    }
+
     include!(concat!(env!("OUT_DIR"), "/bindings_heimdal_client.rs"));
 }
 
@@ -354,6 +393,12 @@ pub mod heimdal_server {
 
     pub fn libraries() -> Vec<&'static str> {
         env!("KADMIN_BUILD_HEIMDAL_SERVER_LIBRARIES")
+            .split_whitespace()
+            .collect()
+    }
+
+    pub fn sonames() -> Vec<&'static str> {
+        env!("KADMIN_BUILD_HEIMDAL_SERVER_SONAMES")
             .split_whitespace()
             .collect()
     }


### PR DESCRIPTION
## Changes

Adds reading the SONAME from each library's unversioned `.so` symlink at build time via `goblin`, embeds the SONAMEs as `KADMIN_BUILD_*_SONAMES` env vars, and tries them first in `find_library`. 

SONAME lookups go through the ldconfig cache, which resolves against the runtime packages without needing the dev-package symlinks. 

The existing path-based and unversioned-name fallbacks are kept, so any setup that works today keeps working.

## Why?

To avoid requiring dev packages at runtime.

## Why? (longer)

`find_library` constructs dlopen paths as `format!("{}/lib{}.so", path, library)` and the fallback path uses the unversioned `lib*.so` directly. 

On Debian/Ubuntu those unversioned `.so` files ship **only* in the dev packages: `krb5-multidev` and  `heimdal-multidev`. 

The runtime packages (`libkadm5clnt-mit12`,  `libkadm5clnt7t64-heimdal`, ...) ship only the SONAME-versioned files  (`libkadm5clnt_mit.so.12`, `libkadm5clnt.so.7`, ...) 

-------------

## Verification notes

I ran through these to make sure everything works, noting them here if needed in the future, feel free to skip reading.

* Spin up a new docker container: `docker run -it --rm ubuntu:24.04 bash`
* Install the dev packages: `apt install krb5-multidev heimdal-multidev libkrb5-dev`
* (Download the project and setup Rust)
* Build: `cargo build --features log 2>&1` and check the SONAMEs are discovered:
```
warning: kadmin@0.7.1: Found MIT Kerberos kadm5-client. Includes: {"/usr/include/mit-krb5"}. Links: {"/usr/lib/x86_64-linux-gnu/mit-krb5"}. Libraries: {"kadm5clnt_mit"}. SONAMEs: {"libkadm5clnt_mit.so.12"}
warning: kadmin@0.7.1: Found MIT Kerberos kadm5-server. Includes: {"/usr/include/mit-krb5"}. Links: {"/usr/lib/x86_64-linux-gnu/mit-krb5"}. Libraries: {"kadm5srv_mit"}. SONAMEs: {"libkadm5srv_mit.so.12"}
warning: kadmin@0.7.1: Found Heimdal Kerberos kadm5-client. Includes: {"/usr/include/heimdal"}. Links: {"/usr/lib/x86_64-linux-gnu/heimdal"}. Libraries: {"kadm5clnt"}. SONAMEs: {"libkadm5clnt.so.7"}
warning: kadmin@0.7.1: Found Heimdal Kerberos kadm5-server. Includes: {"/usr/include/heimdal"}. Links: {"/usr/lib/x86_64-linux-gnu/heimdal"}. Libraries: {"kadm5srv"}. SONAMEs: {"libkadm5srv.so.8"}
```
* Run the tests and check the trace logs:
    * `cargo test --features log --no-run`
    * `RUST_LOG=trace target/debug/deps/kadmin-* --nocapture sys::tests:: 2>&1 | grep -v DEBUG`
```
running 4 tests
[TRACE kadmin::sys] Trying to load library at path libkadm5srv.so.8
[TRACE kadmin::sys] Successfully loaded library at libkadm5srv.so.8
test sys::tests::library_load_heimdal_server ... ok
[TRACE kadmin::sys] Trying to load library at path libkadm5clnt.so.7
[TRACE kadmin::sys] Successfully loaded library at libkadm5clnt.so.7
test sys::tests::library_load_heimdal_client ... ok
[TRACE kadmin::sys] Trying to load library at path libkadm5clnt_mit.so.12
[TRACE kadmin::sys] Successfully loaded library at libkadm5clnt_mit.so.12
test sys::tests::library_load_mit_client ... ok
[TRACE kadmin::sys] Trying to load library at path libkadm5srv_mit.so.12
[TRACE kadmin::sys] Successfully loaded library at libkadm5srv_mit.so.12
test sys::tests::library_load_mit_server ... ok
```
* Remove the dev packages: `apt-get purge -y krb5-multidev heimdal-multidev libkrb5-dev`, removing the unversioned `.so` files
* Re-run the tests and check the trace logs:
    * `RUST_LOG=trace target/debug/deps/kadmin-* --nocapture sys::tests:: 2>&1 | grep -v DEBUG`
```
running 4 tests
[TRACE kadmin::sys] Trying to load library at path libkadm5srv.so.8
[TRACE kadmin::sys] Successfully loaded library at libkadm5srv.so.8
test sys::tests::library_load_heimdal_server ... ok
[TRACE kadmin::sys] Trying to load library at path libkadm5clnt.so.7
[TRACE kadmin::sys] Successfully loaded library at libkadm5clnt.so.7
test sys::tests::library_load_heimdal_client ... ok
[TRACE kadmin::sys] Trying to load library at path libkadm5clnt_mit.so.12
[TRACE kadmin::sys] Successfully loaded library at libkadm5clnt_mit.so.12
test sys::tests::library_load_mit_client ... ok
[TRACE kadmin::sys] Trying to load library at path libkadm5srv_mit.so.12
[TRACE kadmin::sys] Successfully loaded library at libkadm5srv_mit.so.12
test sys::tests::library_load_mit_server ... ok
```